### PR TITLE
WIP Suggested api change - pass dependencies via context `this` object

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -120,14 +120,19 @@ AMDManager = function (options) {
     manager.load(module);
   };
 
-  //TODO - we can modify require to call body.apply with an object
-  // whose keys are dep names, and whose bodies are the loaded module
   manager.require = function (deps, body) {
-    var todo = deps.length, _deps = _.clone(deps);
-    var resolve = function (data, i) {
+    var depIdx = deps.length,
+        _deps = _.clone(deps),
+        _context = {};
+
+    // resolve builds up:
+    //   _deps - an array passed as an argument to the factory function
+    //   _context - a map of dep name to dep
+    var resolve = function (data, i, name) {
       _deps[i] = data;
-      if (--todo <= 0) {
-        body.apply({}, _deps);
+      _context[name] = data;
+      if (--depIdx <= 0) {
+        body.apply(_context, _deps);
       }
     };
     if (deps.length === 0) {
@@ -135,7 +140,7 @@ AMDManager = function (options) {
     } else {
       _.each(deps, function (name, i) {
         manager.load(getOrCreate(name), function (data) {
-          resolve(data, i);
+          resolve(data, i, name);
         });
       });
     }

--- a/tests/manager.js
+++ b/tests/manager.js
@@ -155,4 +155,40 @@ describe('AMDManager', function () {
 
   });
 
+  describe('the context of the factory function', function (test) {
+
+    var manager = new AMDManager(),
+        require = manager.require,
+        define  = manager.define;
+
+    before(function () {
+      require(['a', 'b', 'kebab-module'], function (a, b) {
+        expect(a).to.equal(1);
+        expect(b).to.equal(2);
+        expect(this.a).to.equal(a);
+        expect(this.b).to.equal(b);
+        expect(this['kebab-module']).to.equal('skewered');
+        expect(this.kebabModule).to.equal(undefined);
+      });
+    });
+
+    it('should be able to recieve references to dependencies via `this`', function () {
+
+      define('b', ['a', ], function () {
+        return 2;
+      });
+
+      define('a', [], function () {
+        return 1;
+      });
+
+      define('kebab-module', [], function(){
+        return 'skewered';
+      })
+
+    });
+
+  });
+
+
 });


### PR DESCRIPTION
One of the big complaints I hear about requireJs is the double-entry of dependencies as string names, and as function arguments to the module constructor:

```
define(['dep1', 'dep2'], function(dep1, dep2){ ... });
```

It seems that when `apply` is called with an empty object as the context on [line 128](https://github.com/apendua/meteor-amd-manager/blob/master/manager.js#L128), this is a chance where a fuller object could be passed.

I'd propose there would be camelCased variants of the dependency names directly on the context object, as well as exact-string lookups. 

```
define(['dep1', 'fancy-dep'], function(){ 
    test.equal(this.dep1, this['dep1']);
    test.equal(this.fancyDep, this['fancy-dep']);
});
```

Alternately (or in addition), the factory function could be executed in a closure, providing access to the variables as below, but I consider that a bit too "magical", with the currently unused `this` object being a more idiomatic JavaScript way

```
define(['dep1'], function(){ 
  // If you want to reference dependencies, grab them through `this`, or arguments, or require('dep1')
});

```

Let me know if this seems valuable - if not I'm happy to implement in a fork, if not.
